### PR TITLE
Fix classifier of sources jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ project(':api') {
 
                 from components.java
                 artifact sourceJar {
-                    classifier 'source'
+                    classifier 'sources'
                 }
             }
         }
@@ -85,7 +85,7 @@ project(':impl') {
 
                 from components.java
                 artifact sourceJar {
-                    classifier 'source'
+                    classifier 'sources'
                 }
             }
         }


### PR DESCRIPTION
The convention is to use 'sources' and this is what gradle uses when trying to automatically grab sources.
